### PR TITLE
Fix share log file on newer android version

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,25 @@ repositories {
 Add the dependency:     
 > compile 'com.github.tianzhijiexian:Logcat:[Latest release](https://github.com/tianzhijiexian/Logcat/releases)'
 
+Add following code in your AndroidManifest.xml
+
+```xml
+<application>
+    <provider
+        android:authorities="${applicationId}.logcat.provider"
+        android:name="kale.debug.log.LogcatFileProvider"
+        android:exported="false"
+        android:grantUriPermissions="true"
+        >
+
+        <meta-data
+            android:name="android.support.FILE_PROVIDER_PATHS"
+            android:resource="@xml/provider_paths"/>
+
+    </provider>
+</application>
+```
+
 ### More Detail  
 You can see more detail in [Logcat.java](https://github.com/tianzhijiexian/Logcat/blob/master/lib/src/main/java/kale/debug/log/LogCatCmd.java)
 

--- a/lib/src/main/java/kale/debug/log/LogFileDivider.java
+++ b/lib/src/main/java/kale/debug/log/LogFileDivider.java
@@ -1,9 +1,11 @@
 package kale.debug.log;
 
 import android.app.Activity;
+import android.content.Context;
 import android.content.Intent;
 import android.net.Uri;
 import android.os.Environment;
+import android.support.v4.content.FileProvider;
 
 import java.io.File;
 import java.io.FileWriter;
@@ -105,11 +107,13 @@ public class LogFileDivider {
         activity.startActivity(intent);
     }
 
-    public static void shareFile(Activity activity,File file) {
+    public static void shareFile(Context context, File file) {
         Intent sendIntent = new Intent(Intent.ACTION_SEND);
         sendIntent.setType("text/plain");
-        sendIntent.putExtra(Intent.EXTRA_STREAM, Uri.fromFile(file));
-        activity.startActivity(sendIntent);
+        Uri uri = FileProvider.getUriForFile(context,
+                context.getPackageName() + ".logcat.provider", file);
+        sendIntent.putExtra(Intent.EXTRA_STREAM, uri);
+        context.startActivity(sendIntent);
     }
 
 }

--- a/lib/src/main/java/kale/debug/log/LogcatFileProvider.java
+++ b/lib/src/main/java/kale/debug/log/LogcatFileProvider.java
@@ -1,0 +1,8 @@
+package kale.debug.log;
+
+
+import android.support.v4.content.FileProvider;
+
+public class LogcatFileProvider extends FileProvider {
+
+}

--- a/lib/src/main/res/xml/provider_paths.xml
+++ b/lib/src/main/res/xml/provider_paths.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<paths xmlns:android="http://schemas.android.com/apk/res/android">
+    <external-path name="external_files" path="."/>
+</paths>


### PR DESCRIPTION
BTW, really nice library, have some advice:

- Use maven repo instead of `jitpack.io`, which cause gradle sync failed in my machine.
- Expose logcat view for further customization.